### PR TITLE
Add docs for Distributing XRPackages

### DIFF
--- a/docs/creating-an-aug.md
+++ b/docs/creating-an-aug.md
@@ -76,43 +76,10 @@ If everything went successfully you should see a line with `filename.wbn`, which
 
 ## Test The Package
 
-Now that we've created our bundle we should test it in a browser and make sure everything is still working as it should. Fortunately the XRPackage CLI makes testing a package really simple. Just use the run command to test in a browser:
+Now that we've created our bundle we should test it in a browser and make sure everything is still working as it should. Fortunately the XRPackage CLI makes testing a package really simple. Just use the `run` command to test in a browser:
 
 ```bash
 $ xrpk run ./a.wbn
 ```
 
-If everything looks good in the browser we can move onto the next step, publishing our package to the decentralized IPFS network!
-
-## Publish The Package
-
-#### **Note:** Publishing your package to the IPFS/Ethereum network is completely optional. You can use any hosting and distribution platform to share your XRPackages. IPFS is the preferred hosting solution for the Webaverse due to its decentralized trustless infrastructure.
-
-We've successfully bundled our demo application into a bundle that can now be easily shared and consumed by Webaverse users. One way of distributing XRPackages is by publishing them to the decentralized IPFS network. This allows our packages to be browsed from a central directory and removes the requirement of package hosting. [You can browse previously published packages here.](https://xrpackage.org/browse.html)
-
-#### **Note:** The publish functionality in the XRPackage CLI currently only publishes to the Rinkeby testnet. You will need to have a sufficient ETH balance in order to publish packages. You can get free Rinkeby testnet ETH [at the faucet](https://faucet.rinkeby.io/).
-
-Just like in the previous steps, we're going to be using the XRPackage CLI to login to our Ethereum wallet and publish our packages to the network. The following steps assume you have at least a basic familiarity with the Ethereum network.
-
-The first step is to use the login command to either login to an existing wallet, or create a new wallet. This is the wallet we will be using to pay the gas fees for publishing our package. If you create a new wallet using the CLI, make sure to visit the faucet and load it with ETH before attempting to publish a package.
-
-```bash
-$ xrkp login
-# Follow the on-screen prompts to create or import an existing wallet
-```
-
-Once we've associated our wallet, it's always a good idea to double check your information and make sure everything looks as it should:
-
-```bash
-$ xrkp whoami
-```
-
-Once we're happy with our wallet and we're ready to publish, simply issue the `publish` command with the path to your bundle from earlier:
-
-```bash
-$ xrpk publish
-```
-
-#### [Click here to view the smart contracts for XRPackage Publishing](https://github.com/webaverse/contracts)
-
-Congratulations! You've successfully created and published your first XRPackage!
+If everything looks good in the browser we can move onto the next step, [publishing our package](distributing-xrpackage.md) to the decentralized IPFS network!

--- a/docs/creating-an-aug.md
+++ b/docs/creating-an-aug.md
@@ -8,18 +8,18 @@ This guide will walk you through the basic steps for creating an aug for use in 
 XRPackage will be used to package the assets into a bundle. XRPackage supports multiple asset types, this guide will demonstrate packaging an existing WebXR scene. See the [XRPackage overview page](xrpackage-overview.md) for more information on XRPackage and other supported asset types.
 
 # Table Of Contents
-[Table Of Contents](#table-of-contents)
-  - [Prerequisites](#prerequisites)
-  - [Install XRPackage](#install-xrpackage)
-  - [Create The Package Manifest](#create-the-package-manifest)
-  - [Project Files](#project-files)
-  - [Build The Package](#build-the-package)
-  - [Test The Package](#test-the-package)
+
+- [Prerequisites](#prerequisites)
+- [Install XRPackage](#install-xrpackage)
+- [Create The Package Manifest](#create-the-package-manifest)
+- [Project Files](#project-files)
+- [Build The Package](#build-the-package)
+- [Test The Package](#test-the-package)
 
 ## Prerequisites
 
-* Familiarity with the command line
-* NodeJS and NPM installed and available on PATH. See the [NPMJS guide on installing Node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for setup instructions
+- Familiarity with the command line
+- NodeJS and NPM installed and available on PATH. See the [NPMJS guide on installing Node](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) for setup instructions
 
 ## Install XRPackage
 

--- a/docs/distributing-xrpackage.md
+++ b/docs/distributing-xrpackage.md
@@ -20,11 +20,11 @@ We've successfully packaged our demo application into a bundle that can now be e
 
 IPFS is the [InterPlanetary File System](https://ipfs.io/). IPFS is a way to store and find files by storing them against a _cryptographic hash_. This just means some function goes through the contents of your file to automatically calculate a value that uniquely identifies your file (your XRPackage).
 
-IPFS is also an open source, _decentralised_ system - it uses a peer-to-peer protocol instead of storing your files on a single centralised server. This means you can publish your packages yourself, without needing to rely on your own (costly), or someone else's (unreliable or potentially insecure) server!
+IPFS is also an open source, _decentralized_ system - it uses a peer-to-peer protocol instead of storing your files on a single centralized server. This means you can publish your packages yourself, without needing to rely on your own (costly), or someone else's (unreliable or potentially insecure) server!
 
 ## What is Ethereum?
 
-[Ethereum](https://ethereum.org/) is another decentralised open source system with a programmable blockchain. A blockchain is a global shared, transactional database. Data is stored as _blocks_ which are cryptographically linked together - each block contains a cryptographic hash to the previous block and a timestamp. This means the data cannot be altered once it has been published.
+[Ethereum](https://ethereum.org/) is another decentralized open source system with a programmable blockchain. A blockchain is a global shared, transactional database. Data is stored as _blocks_ which are cryptographically linked together - each block contains a cryptographic hash to the previous block and a timestamp. This means the data cannot be altered once it has been published.
 
 Ethereum has a native cryptocurrency ('digital money') called [Ether (ETH)](https://ethereum.org/eth/).
 

--- a/docs/distributing-xrpackage.md
+++ b/docs/distributing-xrpackage.md
@@ -1,0 +1,66 @@
+---
+id: distributing-xrpackage
+title: Distributing XRPackages
+---
+
+Once you've [created your first aug](./creating-an-aug.md), you can optionally publish your package the the IPFS/Ethereum network!
+
+**Note: Publishing your package to the IPFS/Ethereum network is completely optional. You can use any hosting and distribution platform to share your XRPackages. IPFS is the preferred hosting solution for the Webaverse due to its decentralized trustless infrastructure.**
+
+We've successfully packaged our demo application into a bundle that can now be easily shared and consumed by Webaverse users. One way of distributing XRPackages is by publishing them to the decentralized IPFS network. This allows our packages to be browsed from a central directory and removes the requirement of package hosting. [You can browse previously published packages here.](https://xrpackage.org/browse.html)
+
+# Table of Contents
+
+- [What is IPFS?](#what-is-ipfs)
+- [What is Ethereum?](#what-is-ethereum)
+- [What is the Registry?](#what-is-the-registry)
+- [Publishing to IPFS](#publishing-to-ipfs)
+
+## What is IPFS?
+
+IPFS is the [InterPlanetary File System](https://ipfs.io/). IPFS is a way to store and find files by storing them against a _cryptographic hash_. This just means some function goes through the contents of your file to automatically calculate a value that uniquely identifies your file (your XRPackage).
+
+IPFS is also an open source, _decentralised_ system - it uses a peer-to-peer protocol instead of storing your files on a single centralised server. This means you can publish your packages yourself, without needing to rely on your own (costly), or someone else's (unreliable or potentially insecure) server!
+
+## What is Ethereum?
+
+[Ethereum](https://ethereum.org/) is another decentralised open source system with a programmable blockchain. A blockchain is a global shared, transactional database. Data is stored as _blocks_ which are cryptographically linked together - each block contains a cryptographic hash to the previous block and a timestamp. This means the data cannot be altered once it has been published.
+
+Ethereum has a native cryptocurrency ('digital money') called [Ether (ETH)](https://ethereum.org/eth/).
+
+Ethereum gives ownership and interopability of your packages -- you will always have a complete sense of ownership for anything you create and can provably sell anything you own.
+
+## What is the Registry?
+
+The Registry is a simple database that maps user-friendly names to the unique long hashes produced by the IPFS. This means you can give your package the name `chicken` instead of its hash `QmdVXHq9TWdcDeHQmYAWQpCp8pnXx96Jc9PxJVdUVstTB9` (see [here](https://xrpackage.org/inspect.html?p=chicken)) making it more discoverable and user-friendly.
+
+You can browse the XRPackage Registry at [xrpackage.org](https://xrpackage.org/browse.html).
+
+## Publishing to IPFS
+
+**Note: The publish functionality in the XRPackage CLI currently only publishes to the Rinkeby testnet. You will need to have a sufficient ETH balance in order to publish packages. You can get free Rinkeby testnet ETH [at the faucet](https://faucet.rinkeby.io/).**
+
+Just like in the previous steps, we're going to be using the XRPackage CLI to login to our Ethereum wallet and publish our packages to the network. The following steps assume you have at least a basic familiarity with the Ethereum network.
+
+The first step is to use the login command to either login to an existing wallet, or create a new wallet. This is the wallet we will be using to pay the gas fees for publishing our package. If you create a new wallet using the CLI, make sure to visit the faucet and load it with ETH before attempting to publish a package.
+
+```bash
+$ xrpk login
+# Follow the on-screen prompts to create or import an existing wallet
+```
+
+Once we've associated our wallet, it's always a good idea to double check your information and make sure everything looks as it should:
+
+```bash
+$ xrpk whoami
+```
+
+Once we're happy with our wallet and we're ready to publish, simply issue the `publish` command with the path to your bundle from earlier:
+
+```bash
+$ xrpk publish ./path/to/.wbn
+```
+
+**[Click here to view the smart contracts for XRPackage Publishing](https://github.com/webaverse/contracts)**.
+
+Congratulations! You've successfully created and published your first XRPackage!

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ A virtual reality HMD is recommended to enjoy the full experience and capabiliti
 
 * [XRPackage Overview](xrpackage-overview.md)
 * [Create Your First Aug](creating-an-aug.md)
+* [Distributing your XRPackage](distributing-xrpackage.md)
 
 # For Users
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,7 @@ In addition to support traditional 3D models, Webaverse can also package and use
 
 ## 🦸 Developers
 
-Are you a Javascript developer who wants to build spatialized applications for Webaverse? Check out our developer guides for more information on getting started with building functional augs that bring your visions into reality!
+Are you a JavaScript developer who wants to build spatialized applications for Webaverse? Check out [our developer guides](getting-started.md) for more information on getting started with building functional augs that bring your visions into reality!
 
 The Webaverse ecosystem is built on existing open web standards like WebXR, IPFS, and Ethereum.
 

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -46,6 +46,11 @@ class Footer extends React.Component {
             <a href={this.docUrl('getting-started.html')}>
               Getting Started
             </a>
+            <a href="https://github.com/webaverse/docs"
+              target="_blank"
+              rel="noreferrer noopener">
+              Contribute
+            </a>
           </div>
           <div>
             <h5>Community</h5>


### PR DESCRIPTION
This pull request adds a page on Distributing XRPackages and gives a small intro to IPFS, Ethereum and the Registry. I've also moved the existing distribution docs from creating-an-aug into this page, to split up the content more easily.

Also added:
- a link to this repo in the footer called `Contribute`
- a link to the getting-started page from the homepage under the 'Developers' section