### PR TITLE
Unpublish docs

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.webaverse.com


### PR DESCRIPTION
This removes the docs from `docs.webaverse.com`.

They aren't done yet, and there is no active maintainer. In the meantime the incomplete state is causing confusion. We can publish once the content is complete and we have a well-tested (in terms of user testing) start page.