### PR TITLE
Add initial stub pages for XRPackage and XRPackageEngine APIs

### DIFF
--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -1,0 +1,72 @@
+---
+id: xrpackage-api
+title: XRPackage API
+---
+
+The `XRPackage` API is documented here. See install instructions and development setup <a href="https://github.com/webaverse/xrpackage" target="_blank" rel="noopener noreferrer">at the GitHub repository</a>.
+
+The `XRPackageEngine` API is documented [in the next section](./8-xrpackage-engine-api.md).
+
+**Note: This page is still in development, whilst the API is documented**.
+
+## `constructor`
+
+## `add`
+
+## `addFile`
+
+## `clone`
+
+## `compileFromFile`
+
+## `compileRaw`
+
+## `download`
+
+## `ensureRunStop`
+
+## `export`
+
+## `getAabb`
+
+## `getHash`
+
+## `getMainData`
+
+## `getManifestJson`
+
+## `getModel`
+
+## `getParentEngine`
+
+## `getScreenshotImage()`
+
+## `getScreenshotImageUrl()`
+
+## `getVolumeMesh`
+
+## `grabrelease`
+
+## `isAttached`
+
+## `load`
+
+## `loadAvatar`
+
+## `remove`
+
+## `removeFile`
+
+## `setMatrix`
+
+## `setPose`
+
+## `setSchema`
+
+## `setXrFramebuffer`
+
+## `upload`
+
+## `waitForLoad`
+
+## `waitForRun`

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -41,7 +41,15 @@ The `XRPackageEngine` API is documented [in the next section](./8-xrpackage-engi
 
 ## `getScreenshotImage()`
 
+**Parameters**: None
+
+**Returns**: an <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image" target="_blank" rel="noopener noreferrer">`Image`</a> object with `src` set to the result of [`getScreenshotImageUrl()`](#getscreenshotimageurl), or `null` if no image is available.
+
 ## `getScreenshotImageUrl()`
+
+**Parameters**: None
+
+**Returns**: a <a href="https://developer.mozilla.org/en-US/docs/Web/API/DOMString" target="_blank" rel="noopener noreferrer">`DOMString`</a> for the first image in the manifest's `icons` array, or `null` if there is no manifest/icon.
 
 ## `getVolumeMesh`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -1,0 +1,96 @@
+---
+id: xrpackage-engine-api
+title: XRPackageEngine API
+---
+
+The `XRPackageEngine` API is documented here. See install instructions and development setup <a href="https://github.com/webaverse/xrpackage" target="_blank" rel="noopener noreferrer">at the GitHub repository</a>.
+
+The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md).
+
+**Note: This page is still in development, whilst the API is documented**.
+
+## `constructor`
+
+## `defaultAvatar`
+
+## `dispatchXrEvent`
+
+## `downloadScene`
+
+## `draw`
+
+## `equip`
+
+## `exportScene`
+
+## `getContext`
+
+## `getEnv`
+
+## `getProxySession`
+
+## `getUserMedia`
+
+## `grabdown`
+
+## `grabtriggerdown`
+
+## `grabup`
+
+## `grabuse`
+
+## `importScene`
+
+## `listen`
+
+## `packageCancelAnimationFrame`
+
+## `packageRequestAnimationFrame`
+
+## `packageRequestPresent`
+
+## `render`
+
+## `reset`
+
+## `resize`
+
+## `setCamera`
+
+## `setClearFreeFramebuffer`
+
+## `setEnv`
+
+## `setGamepadsConnected`
+
+## `setMatrix`
+
+## `setMicrophoneMediaStream`
+
+## `setRigMatrix`
+
+## `setScale`
+
+## `setSession`
+
+## `setXrFramebuffer`
+
+## `start`
+
+## `tick`
+
+## `updateMatrixWorld`
+
+## `start`
+
+## `tick`
+
+## `updateMatrixWorld`
+
+## `uploadScene`
+
+## `waitForLoad`
+
+## `wearAvatar`
+
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,8 @@ Please have a look at the [Glossary](glossary.md) if you come across any terms y
 - [Technical Notes](./dev-guides/4-technical-notes.md)
 - [Examples](./dev-guides/5-examples.md)
 - [WebXR Overview](./dev-guides/6-webxr-overview.md)
+- [`XRPackage` API](./dev-guides/7-xrpackage-api.md)
+- [`XRPackageEngine` API](./dev-guides/8-xrpackage-engine-api.md)
 
 ## For Users
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,6 +7,9 @@
       "dev-guides/distributing-xrpackage",
       "dev-guides/technical-notes",
       "dev-guides/examples",
+      "dev-guides/xrpackage-api",
+      "dev-guides/xrpackage-engine-api",
+      "dev-guides/examples",
       {
         "type": "subcategory",
         "label": "Asset type guides",


### PR DESCRIPTION
As part of #5.

This PR adds initial stubs and pages for the `XRPackage` and `XRPackageEngine` API, which can be documented as we begin testing XRPackage.

I've also added initial docs for `getScreenshotImage` and `getScreenshotImageUrl`.

>![New XRPackage API page](https://user-images.githubusercontent.com/8850830/88295373-3e26b780-ccf5-11ea-9753-092800462c56.png)


>![getScreenshot* methods](https://user-images.githubusercontent.com/8850830/88295600-89d96100-ccf5-11ea-872c-7e5a13b8c554.png)
