### PR TITLE
Add more XRPackage docs

### DIFF
--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -9,7 +9,19 @@ The `XRPackageEngine` API is documented [in the next section](./8-xrpackage-engi
 
 **Note: This page is still in development, whilst the API is documented**.
 
-## `constructor`
+## `constructor(a)`
+
+**Parameters**: `a` can either be an `XRPackage` instance (to duplicate it), or a `Uint8Array` of data for a `.wbn` XRPackage.
+
+**Returns**: an `XRPackage` instance.
+
+**Example**:
+
+```js
+const p = await fetch("/a.wbn")
+  .then((res) => res.arrayBuffer())
+  .then((uint8Array) => new XRPackage(uint8Array));
+```
 
 ## `add`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -66,13 +66,20 @@ Downloads and returns an XRPackage object with the specified hash from IPFS.
 
 ## `getParentEngine`
 
-## `getScreenshotImage()`
+## `async getScreenshotImage()`
 
 **Parameters**: None
 
 **Returns**: an <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image" target="_blank" rel="noopener noreferrer">`Image`</a> object with `src` set to the result of [`getScreenshotImageUrl()`](#getscreenshotimageurl), or `null` if no image is available.
 
-## `getScreenshotImageUrl()`
+**Example**:
+
+```js
+const image = await p.getScreenshotImage();
+if (image) document.getElementById("image").appendChild(image);
+```
+
+## `async getScreenshotImageUrl()`
 
 **Parameters**: None
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -27,7 +27,11 @@ const p = await fetch("/a.wbn")
 
 ## `addFile`
 
-## `clone`
+## `clone()`
+
+**Parameters**: None
+
+**Returns**: an `XRPackage` instance duplicating the current XRPackage.
 
 ## `compileFromFile`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -114,7 +114,11 @@ Downloads and returns an XRPackage object with the specified hash from IPFS.
 
 ## `ensureRunStop`
 
-## `export`
+## `export()`
+
+**Parameters**: None
+
+**Returns**: a `Uint8Array` representing the XRPackage's data.
 
 ## `getAabb`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -53,6 +53,33 @@ await packageEngine.add(p);
 
 ## `compileRaw(files)`
 
+**Parameters**: `files` is an array of objects with keys `url`, `type`, `data` for the path, MIME type, and body (string or `Uint8Array`) of each file in the XRPackage to be compiled.
+
+**Returns**: A `Uint8Array` representing the `XRPackage` for the files passed in.
+
+**Example**:
+
+```js
+const uint8Array = XRPackage.compileRaw([
+  {
+    url: "/manifest.json",
+    type: "application/json",
+    data: JSON.stringify({
+      xr_type: "webxr-site@0.0.1",
+      start_url: "index.html",
+    }),
+  },
+  {
+    url: "/index.html",
+    type: "text/html",
+    data: "<html>...</html>",
+  },
+]);
+const p = new XRPackage(uint8Array);
+await p.waitForLoad();
+await packageEngine.add(p);
+```
+
 ## `download`
 
 Downloads and returns an XRPackage object with the specified hash from IPFS.

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -126,7 +126,7 @@ if (image) document.getElementById("image").appendChild(image);
 
 **Parameters**: None
 
-**Returns**: a <a href="https://developer.mozilla.org/en-US/docs/Web/API/DOMString" target="_blank" rel="noopener noreferrer">`DOMString`</a> for the first image in the manifest's `icons` array, or `null` if there is no manifest/icon.
+**Returns**: an <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL" target="_blank" rel="noopener noreferrer">Object URL</a> for the first image in the manifest's `icons` array, or `null` if there is no manifest/icon.
 
 ## `getVolumeMesh`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -52,7 +52,11 @@ Downloads and returns an XRPackage object with the specified hash from IPFS.
 
 ## `getMainData`
 
-## `getManifestJson`
+## `getManifestJson()`
+
+**Parameters**: None
+
+**Returns**: an object representing the package's root `manifest.json`, or `null` if the file is not found.
 
 ## `getModel`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -33,9 +33,25 @@ const p = await fetch("/a.wbn")
 
 **Returns**: an `XRPackage` instance duplicating the current XRPackage.
 
-## `compileFromFile`
+## `async compileFromFile(blob)`
 
-## `compileRaw`
+**Parameters**: `blob` is a <a href="https://developer.mozilla.org/en-US/docs/Web/API/Blob" target="_blank" rel="noopener noreferrer">`Blob`</a> object representing the asset that is to be compiled into an `XRPackage`.
+
+**Returns**: A `Uint8Array` representing the `XRPackage` for the asset in `blob`.
+
+**Example**:
+
+```js
+const path = "/camera.glb";
+const blob = await fetch(path).then((res) => res.blob());
+blob.name = path.split("/").pop();
+const uint8Array = await XRPackage.compileFromFile(blob);
+const p = new XRPackage(uint8Array);
+await p.waitForLoad();
+await packageEngine.add(p);
+```
+
+## `compileRaw(files)`
 
 ## `download`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -15,6 +15,12 @@ The `XRPackageEngine` API is documented [in the next section](./8-xrpackage-engi
 
 **Returns**: an `XRPackage` instance.
 
+**Throws**: an `Error` if `a.byteLength > 0` and either:
+
+- no `manifest.json` was found in the package,
+- no `xr_type` or `start_url` is find in the manifest,
+- an unknown `xr_type` was provided
+
 **Example**:
 
 ```js

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -106,7 +106,18 @@ Uploads the XRPackage to the IPFS directory and returns the IPFS hash of the pac
 
 **Returns**: `hash`, a string containing the IPFS hash of the newly uploaded package.
 
+## `async waitForLoad()`
 
-## `waitForLoad`
+**Parameters**: None
+
+**Returns**: a `Promise` that resolves when the package has been parsed and it's loader completes successfully.
+
+**Example**:
+
+```js
+const p = new XRPackage(uint8Array);
+await p.waitForLoad();
+await packageEngine.add(p);
+```
 
 ## `waitForRun`

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -169,7 +169,13 @@ Retrieve the collision mesh of the XRPackage if it exists.
 
 ## `remove`
 
-## `removeFile`
+## `removeFile(pathname)`
+
+_Removes a file from the XRPackage._
+
+**Parameters**: `pathname` is the path of the file to remove from the package.
+
+**Returns**: Nothing
 
 ## `setMatrix`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -109,14 +109,13 @@ await p.waitForLoad();
 await packageEngine.add(p);
 ```
 
-## `download`
+## `async download(hash)`
 
-Downloads and returns an XRPackage object with the specified hash from IPFS.
+_Downloads and returns an XRPackage object with the specified hash from IPFS._
 
 **Parameters**: `hash`, a string of the IPFS package hash to be downloaded.
 
 **Returns**: `p`. an `XRPackage` object
-
 
 ## `ensureRunStop`
 
@@ -161,9 +160,9 @@ if (image) document.getElementById("image").appendChild(image);
 
 **Returns**: an <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL" target="_blank" rel="noopener noreferrer">Object URL</a> for the first image in the manifest's `icons` array, or `null` if there is no manifest/icon.
 
-## `getVolumeMesh`
+## `async getVolumeMesh()`
 
-Retrieve the collision mesh of the XRPackage if it exists.
+_Retrieve the collision mesh of the XRPackage if it exists._
 
 **Parameters**: None
 
@@ -195,9 +194,9 @@ _Removes a file from the XRPackage._
 
 ## `setXrFramebuffer`
 
-## `upload`
+## `async upload()`
 
-Uploads the XRPackage to the IPFS directory and returns the IPFS hash of the package.
+_Uploads the XRPackage to the IPFS directory and returns the IPFS hash of the package._
 
 **Parameters**: None
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -25,7 +25,30 @@ const p = await fetch("/a.wbn")
 
 ## `add`
 
-## `addFile`
+## `addFile(pathname, data, type)`
+
+_Adds a file to the XRPackage._
+
+**Parameters**:
+
+- `pathname` is the path for the file to add
+- `data` is a string or `Uint8Array` representing the file to add
+- `type` is the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types" target="_blank" rel="noopener noreferrer">MIME type</a> for the file to add
+
+**Returns**: Nothing
+
+**Example**:
+
+```js
+const uint8Array = await fetch("/avatar.vrm").then((res) => res.arrayBuffer());
+const xrpk = new XRPackage();
+xrpk.addFile(
+  "manifest.json",
+  JSON.stringify({ start_url: "avatar.vrm", xr_type: "vrm@0.0.1" }),
+  "application/json"
+);
+xrpk.addFile("avatar.vrm", uint8Array, "application/octet-stream");
+```
 
 ## `clone()`
 


### PR DESCRIPTION
~_marked as draft whilst I keep adding methods to the docs_~

Documents:

- XRPackage constructor
- XRPackage `async waitForLoad()`
- XRPackage `getManifestJson()`
- XRPackage `clone()`
- XRPackage `async compileFromFile(blob)`
- XRPackage `compileRaw(files)`
- XRPackage `addFile(pathname, data, type)`
- XRPackage `removeFile(pathname)`
- XRPackage `export()`

Improves:

- XRPackage `getScreenshotImage()` and `getScreenshotImageUrl()` and adds an example for the former

Part of #5.