### PR TITLE
Document more API methods

### DIFF
--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -190,7 +190,11 @@ _Retrieve the collision mesh of the XRPackage if it exists._
 
 ## `grabrelease`
 
-## `isAttached`
+## `isAttached()`
+
+**Parameters**: None
+
+**Returns**: a `Boolean` representing whether the current package is attached to an `XRPackageEngine` instance.
 
 ## `load`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -125,7 +125,11 @@ _Downloads and returns an XRPackage object with the specified hash from IPFS._
 
 **Returns**: a `Uint8Array` representing the XRPackage's data.
 
-## `getAabb`
+## `getAabb()`
+
+**Parameters**: None
+
+**Returns**: `null` if this package's manifest is missing/invalid/has no `aabb` property, or the `THREE.Box3` representing this package's AABB Box.
 
 ## `getHash`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -240,4 +240,8 @@ await p.waitForLoad();
 await packageEngine.add(p);
 ```
 
-## `waitForRun`
+## `async waitForRun()`
+
+**Parameters**: None
+
+**Returns**: a `Promise` that resolves once this package is attached to an `XRPackageEngine` instance.

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -196,8 +196,6 @@ _Retrieve the collision mesh of the XRPackage if it exists._
 
 **Returns**: a `Boolean` representing whether the current package is attached to an `XRPackageEngine` instance.
 
-## `load`
-
 ## `loadAvatar`
 
 ## `remove`
@@ -215,8 +213,6 @@ _Removes a file from the XRPackage._
 ## `setPose`
 
 ## `setSchema`
-
-## `setXrFramebuffer`
 
 ## `async upload()`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -137,7 +137,11 @@ _Downloads and returns an XRPackage object with the specified hash from IPFS._
 
 **Returns**: a `Promise` that resolves to the hash of this package's data.
 
-## `getMainData`
+## `getMainData()`
+
+**Parameters**: None
+
+**Returns**: the body of the contents of the `start_url` file of this package.
 
 ## `getManifestJson()`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -149,7 +149,11 @@ _Downloads and returns an XRPackage object with the specified hash from IPFS._
 
 **Returns**: an object representing the package's root `manifest.json`, or `null` if the file is not found.
 
-## `getModel`
+## `async getModel()`
+
+**Parameters**: None
+
+**Returns**: a `Promise` that resolves to `null` if there is no model defined in this package's manifest, otherwise the parsed model for this package.
 
 ## `getParentEngine()`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -151,7 +151,11 @@ _Downloads and returns an XRPackage object with the specified hash from IPFS._
 
 ## `getModel`
 
-## `getParentEngine`
+## `getParentEngine()`
+
+**Parameters**: None
+
+**Returns**: `null` if there is no parent `XRPackageEngine`, or the `XRPackageEngine` instance for this package.
 
 ## `async getScreenshotImage()`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -131,7 +131,11 @@ _Downloads and returns an XRPackage object with the specified hash from IPFS._
 
 **Returns**: `null` if this package's manifest is missing/invalid/has no `aabb` property, or the `THREE.Box3` representing this package's AABB Box.
 
-## `getHash`
+## `async getHash()`
+
+**Parameters**: None
+
+**Returns**: a `Promise` that resolves to the hash of this package's data.
 
 ## `getMainData`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -105,7 +105,15 @@ _Removes all the children of the XRPackageEngine instance._
 
 ## `updateMatrixWorld`
 
-## `uploadScene`
+## `async uploadScene()`
+
+_Uploads the current scene to the Webaverse IPFS backend._
+
+**Parameters**: None
+
+**Returns**: a string that is the IPFS hash of the uploaded scene.
+
+**Throws**: an `Error` if there is an error uploading the scene (i.e. if the network request does not return a 200 status).
 
 ## `waitForLoad()`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -83,8 +83,6 @@ _Downloads & imports an arbitrary scene from IPFS into the Engine._
 
 ## `getProxySession`
 
-## `getUserMedia`
-
 ## `grabdown`
 
 ## `grabtriggerdown`
@@ -109,11 +107,7 @@ _Attaches a `resize` event listener to automatically respond to resize events._
 
 **Returns**: Nothing
 
-## `packageCancelAnimationFrame`
-
 ## `packageRequestAnimationFrame`
-
-## `packageRequestPresent`
 
 ## `remove(p, reason)`
 
@@ -225,14 +219,6 @@ _Sets the XR Framebuffer for the engine's iframe._
 **Parameters**: `xrfb`, the framebuffer to be set.
 
 **Returns**: Nothing
-
-## `start`
-
-## `tick`
-
-## `updateMatrixWorld`
-
-## `start`
 
 ## `tick`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -139,7 +139,13 @@ _Resizes this XRPackageEngine instance._
 
 ## `setClearFreeFramebuffer`
 
-## `setEnv`
+## `setEnv(key, value)`
+
+_Sets a single key-value environment pair._
+
+**Parameters**: a `key` and `value` to be associated with that `key`.
+
+**Returns**: Nothing
 
 ## `setGamepadsConnected(connected)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -9,7 +9,19 @@ The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md
 
 **Note: This page is still in development, whilst the API is documented**.
 
-## `constructor`
+## `constructor(options)`
+
+**Parameters**: `options` is an optional Object, where all the following keys are also optional:
+
+| Key                | Default                   | Description                                       |
+|--------------------|---------------------------|---------------------------------------------------|
+| `width`            | `window.innerWidth`       | The width of the renderer                         |
+| `height`           | `window.innerHeight`      | The height of the renderer                        |
+| `devicePixelRatio` | `window.devicePixelRatio` | The pixel ratio of the renderer                   |
+| `autoStart`        | `true`                    | Whether to auto start the XR Session              |
+| `autoListen`       | `true`                    | Whether to automatically listen to window resizes |
+
+**Returns**: an `XRPackageEngine` instance.
 
 ## `defaultAvatar`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -23,6 +23,17 @@ The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md
 
 **Returns**: an `XRPackageEngine` instance.
 
+## `async add(p, reason)`
+
+_Adds an `XRPackage` to the engine, and blocks until it is loaded._
+
+**Parameters**:
+
+- `p`: the `XRPackage` object to add
+- `reason`: an optional string describing the reason for adding the package
+
+**Returns**: a `Promise` that resolves when the package is fully loaded.
+
 ## `defaultAvatar`
 
 ## `dispatchXrEvent`

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -82,6 +82,19 @@ _Downloads & imports an arbitrary scene from IPFS into the Engine._
 
 ## `packageRequestPresent`
 
+## `remove(p, reason)`
+
+_Removes an XRPackage from the Engine._
+
+**Parameters**:
+
+- `p` is the `XRPackage` to remove
+- `reason` is an optional string describing why the package is being removed
+
+**Returns**: Nothing
+
+**Throws** an `Error` if the given `p` is not a child of this `XRPackageEngine` instance.
+
 ## `render`
 
 ## `reset()`

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -64,7 +64,11 @@ _Downloads & imports an arbitrary scene from IPFS into the Engine._
 
 ## `getContext`
 
-## `getEnv`
+## `getEnv(key)`
+
+**Parameters**: the `key` for which you want to get the corresponding `value`.
+
+**Returns**: the corresponding `value` for the given `key`.
 
 ## `getProxySession`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -203,7 +203,13 @@ _Sets the rig matrix (the offset of the user's avatar from the scene's camera, u
 
 ## `setSession`
 
-## `setXrFramebuffer`
+## `setXrFramebuffer(xrfb)`
+
+_Sets the XR Framebuffer for the engine's iframe._
+
+**Parameters**: `xrfb`, the framebuffer to be set.
+
+**Returns**: Nothing
 
 ## `start`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -221,7 +221,13 @@ _Sets the XR Framebuffer for the engine's iframe._
 
 ## `tick`
 
-## `updateMatrixWorld`
+## `updateMatrixWorld()`
+
+_Updates the matrix world for all the children of this `XRPackageEngine`, if necessary._
+
+**Parameters**: None
+
+**Returns**: Nothing
 
 ## `async uploadScene()`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -48,7 +48,7 @@ _Adds an `XRPackage` to the engine, and blocks until it is loaded._
 
 **Parameters**: None
 
-**Returns**: A `Uint8Array` representing the `.wbn` bundle for the current scene.
+**Returns**: a `Promise` that resolves with a `Uint8Array` representing the `.wbn` bundle for the current scene.
 
 ## `getContext`
 
@@ -126,7 +126,7 @@ _Uploads the current scene to the Webaverse IPFS backend._
 
 **Parameters**: None
 
-**Returns**: a string that is the IPFS hash of the uploaded scene.
+**Returns**: a `Promise` that resolves with a string which is the IPFS hash of the uploaded scene.
 
 **Throws**: an `Error` if there is an error uploading the scene (i.e. if the network request does not return a 200 status).
 
@@ -134,7 +134,7 @@ _Uploads the current scene to the Webaverse IPFS backend._
 
 **Parameters**: None
 
-**Returns**: A Promise that resolves when the `XRPackageInstance` is initialised and the service worker has been registered successfully.
+**Returns**: a Promise that resolves when the `XRPackageInstance` is initialised and the service worker has been registered successfully.
 
 ## `wearAvatar`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -78,7 +78,13 @@ _Downloads & imports an arbitrary scene from IPFS into the Engine._
 
 ## `grabuse`
 
-## `importScene`
+## `async importScene(uint8Array)`
+
+_Imports a scene into the current `XRPackageEngine`._
+
+**Parameters**: `uint8Array` is a `Uint8Array` representing an XRPackage `.wbn` file
+
+**Returns**: a `Promise` that resolves when the package is loaded and added to this `XRPackageEngine` instance, and rejects if the `XRPackage` to be added is not an `xrpackage-scene@0.0.1`.
 
 ## `listen`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -42,7 +42,18 @@ _Sets the avatar of this XRPackageEngine to the default avatar, with fingers and
 
 **Returns**: Nothing
 
-## `dispatchXrEvent`
+## `dispatchXrEvent(p, type, data, onresponse)`
+
+_Sends an XR event message to all the children in this `XRPackageEngine` instance._
+
+**Parameters**:
+
+- `p` is an `XRPackage` that is sending the event
+- `type` is the type of message
+- `data` is the data to send
+- `onresponse` is a function that is called with the parameter `response` when the event is handled
+
+**Returns**: Nothing
 
 ## `async downloadScene(hash)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -90,7 +90,13 @@ _Imports a scene into the current `XRPackageEngine`._
 
 **Returns**: a `Promise` that resolves when the package is loaded and added to this `XRPackageEngine` instance, and rejects if the `XRPackage` to be added is not an `xrpackage-scene@0.0.1`.
 
-## `listen`
+## `listen()`
+
+_Attaches a `resize` event listener to automatically respond to resize events._
+
+**Parameters**: None
+
+**Returns**: Nothing
 
 ## `packageCancelAnimationFrame`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -33,7 +33,11 @@ The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md
 
 ## `equip`
 
-## `exportScene`
+## `async exportScene()`
+
+**Parameters**: None
+
+**Returns**: A `Uint8Array` representing the `.wbn` bundle for the current scene.
 
 ## `getContext`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -212,7 +212,11 @@ _Sets the rig matrix (the offset of the user's avatar from the scene's camera, u
 
 **Returns**: Nothing
 
-## `setSession`
+## `async setSession(realSession)`
+
+**Parameters**: `realSession` is the <a href="https://developer.mozilla.org/en-US/docs/Web/API/XRSession" target="_blank" rel="noopener noreferrer">`XRSession`</a> to set for this `XRPackageEngine` instance.
+
+**Returns**: a `Promise` that resolves when the session has been successfully set.
 
 ## `setXrFramebuffer(xrfb)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -171,7 +171,21 @@ _Sets the matrix for this `XRPackageEngine` and sets all the children to need th
 
 **Returns**: Nothing
 
-## `setMicrophoneMediaStream`
+## `setMicrophoneMediaStream(mediaStream)`
+
+**Parameters**: `mediaStream` is the media stream to set for this `XRPackageEngine`.
+
+**Returns**: Nothing
+
+**Example**:
+
+```js
+const pe = new XRPackageEngine();
+const mediaStream = await navigator.mediaDevices.getUserMedia({
+  audio: true,
+});
+pe.setMicrophoneMediaStream(mediaStream);
+```
 
 ## `setRigMatrix`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -38,7 +38,13 @@ _Adds an `XRPackage` to the engine, and blocks until it is loaded._
 
 ## `dispatchXrEvent`
 
-## `downloadScene`
+## `async downloadScene(hash)`
+
+_Downloads & imports an arbitrary scene from IPFS into the Engine._
+
+**Parameters**: `hash` is the IPFS hash of the scene to be downloaded
+
+**Returns**: a `Promise` that resolves when the scene is downloaded and imported successfully, or rejects when there is a non-200 response when downloading or the downloaded scene is invalid.
 
 ## `draw`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -34,7 +34,13 @@ _Adds an `XRPackage` to the engine, and blocks until it is loaded._
 
 **Returns**: a `Promise` that resolves when the package is fully loaded.
 
-## `defaultAvatar`
+## `defaultAvatar()`
+
+_Sets the avatar of this XRPackageEngine to the default avatar, with fingers and hair, in debug mode._
+
+**Parameters**: None
+
+**Returns**: Nothing
 
 ## `dispatchXrEvent`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -125,7 +125,11 @@ _Removes all the children of the XRPackageEngine instance._
 
 ## `setRigMatrix`
 
-## `setScale`
+## `setScale(scale)`
+
+**Parameters**: `scale` is the numeric scale to set for the Engine.
+
+**Returns**: Nothing
 
 ## `setSession`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -111,7 +111,19 @@ _Removes all the children of the XRPackageEngine instance._
 
 **Returns**: Nothing
 
-## `resize`
+## `resize(width, height, devicePixelRatio)`
+
+_Resizes this XRPackageEngine instance._
+
+**Parameters**: all parameters are optional, with defaults as follows:
+
+| Key                | Default                         | Description                         |
+| ------------------ | ------------------------------- | ----------------------------------- |
+| `width`            | `this.options.width`            | The new width of the renderer       |
+| `height`           | `this.options.height`           | The new height of the renderer      |
+| `devicePixelRatio` | `this.options.devicePixelRatio` | The new pixel ratio of the renderer |
+
+**Returns**: Nothing |
 
 ## `setCamera(camera)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -187,7 +187,13 @@ const mediaStream = await navigator.mediaDevices.getUserMedia({
 pe.setMicrophoneMediaStream(mediaStream);
 ```
 
-## `setRigMatrix`
+## `setRigMatrix(rigMatrix)`
+
+_Sets the rig matrix (the offset of the user's avatar from the scene's camera, useful for implementing third-person view modes)._
+
+**Parameters**: the `rigMatrix` to set. If this is falsy, the rig matrix is disabled.
+
+**Returns**: Nothing
 
 ## `setScale(scale)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -163,7 +163,13 @@ _Sets a single key-value environment pair._
 
 **Returns**: Nothing
 
-## `setMatrix`
+## `setMatrix(m)`
+
+_Sets the matrix for this `XRPackageEngine` and sets all the children to need their matrix world updating._
+
+**Parameters**: `m` is the matrix to set.
+
+**Returns**: Nothing
 
 ## `setMicrophoneMediaStream`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -107,7 +107,11 @@ _Removes all the children of the XRPackageEngine instance._
 
 ## `resize`
 
-## `setCamera`
+## `setCamera(camera)`
+
+**Parameters**: `camera` is the camera to set for the Engine (e.g. a `Three.PerspectiveCamera`)
+
+**Returns**: Nothing
 
 ## `setClearFreeFramebuffer`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -107,7 +107,11 @@ _Removes all the children of the XRPackageEngine instance._
 
 ## `uploadScene`
 
-## `waitForLoad`
+## `waitForLoad()`
+
+**Parameters**: None
+
+**Returns**: A Promise that resolves when the `XRPackageInstance` is initialised and the service worker has been registered successfully.
 
 ## `wearAvatar`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -117,7 +117,11 @@ _Removes all the children of the XRPackageEngine instance._
 
 ## `setEnv`
 
-## `setGamepadsConnected`
+## `setGamepadsConnected(connected)`
+
+**Parameters**: `connected` is a `Boolean` representing whether the gamepads are now connected.
+
+**Returns**: Nothing
 
 ## `setMatrix`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -14,7 +14,7 @@ The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md
 **Parameters**: `options` is an optional Object, where all the following keys are also optional:
 
 | Key                | Default                   | Description                                       |
-|--------------------|---------------------------|---------------------------------------------------|
+| ------------------ | ------------------------- | ------------------------------------------------- |
 | `width`            | `window.innerWidth`       | The width of the renderer                         |
 | `height`           | `window.innerHeight`      | The height of the renderer                        |
 | `devicePixelRatio` | `window.devicePixelRatio` | The pixel ratio of the renderer                   |
@@ -63,7 +63,13 @@ The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md
 
 ## `render`
 
-## `reset`
+## `reset()`
+
+_Removes all the children of the XRPackageEngine instance._
+
+**Parameters**: None
+
+**Returns**: Nothing
 
 ## `resize`
 


### PR DESCRIPTION
This PR mainly focuses on the XRPackageEngine API. 

Documents the following methods in `XRPackageEngine`:

- constructor
- reset()
- ~start()~
- waitForLoad()
- uploadScene()
- exportScene()
- add(p, reason)
- downloadScene(hash)
- remove(p, reason)
- setCamera(camera)
- setScale(scale)
- setGamepadsConnected(connected)        
- defaultAvatar()
- resize(width, height, devicePixelRatio)
- importScene(uint8Array)
- setEnv(key, value)
- getEnv(key)
- listen()
- setMatrix(m)
- setMicrophoneMediaStream(mediaStream)
- setRigMatrix(rigMatrix)
- setXrFramebuffer(xrfb)
- updateMatrixWorld()
- dispatchXrEvent(p, type, data, onresponse)
- ~getUserMedia(options)~
- setSession(realSession)
- ~packageCancelAnimationFrame(id)~
- ~packageRequestPresent(p)~

Also some more `XRPackage` methods:

- getAabb()
- getHash()
- getMainData()
- getParentEngine()
- ~load()~
- getModel()
- isAttached()
- ~setXrFramebuffer(xrfb)~

It's looking something like this now:

> ![image](https://user-images.githubusercontent.com/8850830/89884767-e2e43880-dbc1-11ea-9eda-39f7e3c3430c.png)

Part of #5.