### PR TITLE
Finish documenting XRPackage & XRPackageEngine APIs

### DIFF
--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -132,8 +132,6 @@ _Downloads and returns an XRPackage object with the specified hash from IPFS._
 
 **Returns**: `p`. an `XRPackage` object
 
-## `ensureRunStop`
-
 ## `export()`
 
 **Parameters**: None

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -217,7 +217,13 @@ _Releases all grabs on the current package._
 
 **Returns**: a `Boolean` representing whether the current package is attached to an `XRPackageEngine` instance.
 
-## `loadAvatar`
+## `async loadAvatar()`
+
+_Waits for the avatar to load, if applicable._
+
+**Parameters**: None
+
+**Returns**: A `Promise` that resolves when the avatar is loaded/immediately if loading was not applicable.
 
 ## `remove`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -256,7 +256,11 @@ _Removes a file from the XRPackage._
 
 ## `setPose`
 
-## `setSchema`
+## `setSchema(key, value)`
+
+**Parameters**: the `key` and corresponding `value` to set for the schema for this package
+
+**Returns**: Nothing
 
 ## `async upload()`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -30,7 +30,21 @@ const p = await fetch("/a.wbn")
   .then((uint8Array) => new XRPackage(uint8Array));
 ```
 
-## `add`
+## `async add(p, options)`
+
+_Adds an XRPackage to this instance._
+
+**Parameters**:
+
+- `p` is the `XRPackage` instance to add.
+- `options` is an Object with the following optional parameters:
+
+| Key       | Default | Description                                                         |
+| --------- | ------- | ------------------------------------------------------------------- |
+| `reason`  | N/A     | String describing why the package is added                          |
+| `timeout` | 30000   | Milliseconds after which this method should reject if loading fails |
+
+**Returns**: A `Promise` that resolves when the package loads successfully, or rejects if the `timeout` is reached before the load occurs.
 
 ## `addFile(pathname, data, type)`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -252,7 +252,13 @@ _Removes a file from the XRPackage._
 
 **Returns**: Nothing
 
-## `setPose`
+## `setPose(pose)`
+
+_Sets the pose for this avatar._
+
+**Parameters**: `pose` is an array of three arrays: `[head, leftGamepad, rightGamepad]`. The elements for each inner array must be describe the relevant position, quaternion, pointer (if applicable), and grip (if applicable) -- in that order.
+
+**Returns**: Nothing
 
 ## `setSchema(key, value)`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -225,7 +225,20 @@ _Waits for the avatar to load, if applicable._
 
 **Returns**: A `Promise` that resolves when the avatar is loaded/immediately if loading was not applicable.
 
-## `remove`
+## `remove(p, options)`
+
+_Removes an XRPackage from this instance._
+
+**Parameters**:
+
+- `p` is the `XRPackage` instance to remove.
+- `options` is an Object with the following optional parameters:
+
+| Key      | Default | Description                                  |
+| -------- | ------- | -------------------------------------------- |
+| `reason` | N/A     | String describing why the package is removed |
+
+**Returns**: Nothing.
 
 ## `removeFile(pathname)`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -203,7 +203,13 @@ _Retrieve the collision mesh of the XRPackage if it exists._
 
 **Returns**: A <a href="https://threejs.org/docs/#api/en/scenes/Scene" target="_blank" rel="noopener noreferrer">`Scene`</a> object for the package volume mesh if it exists, or `null` if a volume mesh does not exist.
 
-## `grabrelease`
+## `grabrelease()`
+
+_Releases all grabs on the current package._
+
+**Parameters**: None
+
+**Returns**: Nothing
 
 ## `isAttached()`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -248,7 +248,11 @@ _Removes a file from the XRPackage._
 
 **Returns**: Nothing
 
-## `setMatrix`
+## `setMatrix(m)`
+
+**Parameters**: the matrix `m` to set.
+
+**Returns**: Nothing
 
 ## `setPose`
 

--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -8,8 +8,6 @@ The `XRPackage` API is documented here. See install instructions and development
 - The `XRPackageEngine` API is documented [in the next section](./8-xrpackage-engine-api.md).
 - The `XRPackageManager` API is documented [in a later section](./9-xrpackage-manager-api.md).
 
-**Note: This page is still in development, whilst the API is documented**.
-
 ## `constructor(a)`
 
 **Parameters**: `a` can either be an `XRPackage` instance (to duplicate it), or a `Uint8Array` of data for a `.wbn` XRPackage.

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -97,7 +97,13 @@ _Wraps the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasE
 
 **Returns**: the corresponding `value` for the given `key`.
 
-## `getProxySession`
+## `getProxySession(options)`
+
+_Gets the proxied <a href="https://developer.mozilla.org/en-US/docs/Web/API/XRSession" target="_blank" rel="noopener noreferrer">XRSession</a> for this engine instance._
+
+**Parameters**: `options` is an Object with an optional `order` parameter (defaults to `0`).
+
+**Returns**: an `Object` representing the proxied/hijacked <a href="https://developer.mozilla.org/en-US/docs/Web/API/XRSession" target="_blank" rel="noopener noreferrer">XRSession</a> for this engine instance.
 
 ## `grabdown`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -113,7 +113,13 @@ _Marks the given hand as in grabbing mode. Does nothing if there is no avatar/ri
 
 **Returns**: Nothing
 
-## `grabtriggerdown`
+## `grabtriggerdown(handedness)`
+
+_Triggers a grab attempt for the given hand._
+
+**Parameters**: `handedness` is a string out of `left`, `right` that represents which hand is grabbing.
+
+**Returns**: Nothing
 
 ## `grabtriggerup(handedness)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -283,7 +283,16 @@ _Sets the XR Framebuffer for the engine's iframe._
 
 **Returns**: Nothing
 
-## `tick`
+## `tick(timestamp, frame)`
+
+_Performs a single renderer tick._
+
+**Parameters**:
+
+- `timestamp`, which defaults to `performance.now()`
+- `frame`, which defaults to `null`
+
+**Returns**: Nothing
 
 ## `updateMatrixWorld()`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -64,8 +64,6 @@ _Downloads & imports an arbitrary scene from IPFS into the Engine._
 
 **Returns**: a `Promise` that resolves when the scene is downloaded and imported successfully, or rejects when there is a non-200 response when downloading or the downloaded scene is invalid.
 
-## `draw`
-
 ## `equip(slot)`
 
 _Equips the relevant object (note: the engine must have an avatar/rig set)._
@@ -161,8 +159,6 @@ _Attaches a `resize` event listener to automatically respond to resize events._
 
 **Returns**: Nothing
 
-## `packageRequestAnimationFrame`
-
 ## `remove(p, reason)`
 
 _Removes an XRPackage from the Engine._
@@ -205,8 +201,6 @@ _Resizes this XRPackageEngine instance._
 **Parameters**: `camera` is the camera to set for the Engine (e.g. a `Three.PerspectiveCamera`)
 
 **Returns**: Nothing
-
-## `setClearFreeFramebuffer`
 
 ## `setEnv(key, value)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -137,7 +137,13 @@ _Releases the given hand from grabbing mode._
 
 **Returns**: Nothing
 
-## `grabuse`
+## `grabuse(handedness)`
+
+_Marks a grab as being in use._
+
+**Parameters**: `handedness` is a string out of `left`, `right` that represents which hand is grabbing.
+
+**Returns**: Nothing
 
 ## `async importScene(uint8Array)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -66,7 +66,13 @@ _Downloads & imports an arbitrary scene from IPFS into the Engine._
 
 ## `draw`
 
-## `equip`
+## `equip(slot)`
+
+_Equips the relevant object (note: the engine must have an avatar/rig set)._
+
+**Parameters**: The `slot` to store the object in, which must be a string out of `head`, `left`, `right`, and `back`.
+
+**Returns**: Nothing
 
 ## `async exportScene()`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -8,8 +8,6 @@ The `XRPackageEngine` API is documented here. See install instructions and devel
 - The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md).
 - The `XRPackageManager` API is documented [in the next section](./9-xrpackage-manager-api.md).
 
-**Note: This page is still in development, whilst the API is documented**.
-
 ## `constructor(options)`
 
 **Parameters**: `options` is an optional Object, where all the following keys are also optional:

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -80,7 +80,16 @@ _Equips the relevant object (note: the engine must have an avatar/rig set)._
 
 **Returns**: a `Promise` that resolves with a `Uint8Array` representing the `.wbn` bundle for the current scene.
 
-## `getContext`
+## `getContext(type, opts)`
+
+_Wraps the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext" target="_blank" rel="noopener noreferrer">`HTMLCanvasElement.getContext()`</a> method for this `XRPackageEngine` instance_.
+
+**Parameters**:
+
+- `type` corresponds to the `contextType` parameter from the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext" target="_blank" rel="noopener noreferrer">`HTMLCanvasElement.getContext()`</a> method.
+- `opts` corresponds to the `contextAttributes` parameter from the <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext" target="_blank" rel="noopener noreferrer">`HTMLCanvasElement.getContext()`</a> method.
+
+**Returns**: The <a href="https://developer.mozilla.org/en-US/docs/Web/API/RenderingContext" target="_blank" rel="noopener noreferrer">`RenderingContext`</a> of the engine's canvas, or `null` if the context identifier is not supported.
 
 ## `getEnv(key)`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -318,10 +318,10 @@ _Uploads the current scene to the Webaverse IPFS backend._
 
 **Returns**: a Promise that resolves when the `XRPackageInstance` is initialised and the service worker has been registered successfully.
 
-## `wearAvatar`
+## `async wearAvatar(p)`
 
 Wear the specified package as an avatar.
 
 **Parameters**: `p`, an `XRPackage` object.
 
-**Returns**: None
+**Returns**: a `Promise` that resolves when the avatar is worn successfully.

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -115,6 +115,14 @@ _Marks the given hand as in grabbing mode. Does nothing if there is no avatar/ri
 
 ## `grabtriggerdown`
 
+## `grabtriggerup(handedness)`
+
+_Triggers a release-grab attempt for the given hand._
+
+**Parameters**: `handedness` is a string out of `left`, `right` that represents which hand is releasing the grab.
+
+**Returns**: Nothing
+
 ## `grabup(handedness)`
 
 _Releases the given hand from grabbing mode._

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -115,7 +115,13 @@ _Marks the given hand as in grabbing mode. Does nothing if there is no avatar/ri
 
 ## `grabtriggerdown`
 
-## `grabup`
+## `grabup(handedness)`
+
+_Releases the given hand from grabbing mode._
+
+**Parameters**: `handedness` is a string out of `left`, `right` that represents which hand is grabbing.
+
+**Returns**: Nothing
 
 ## `grabuse`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -172,7 +172,22 @@ _Removes an XRPackage from the Engine._
 
 **Throws** an `Error` if the given `p` is not a child of this `XRPackageEngine` instance.
 
-## `render`
+## `render(pak, width, height, viewMatrix, projectionMatrix, framebuffer)`
+
+_Performs a render of the engine (useful when needing to perform manual renders, such as for a packaged mirror)._
+
+**Parameters**: all parameters are required, as follows:
+
+| Key                | Description                                                                                                                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pak`              | The `XRPackage` to render (can be `null`)                                                                                                                                                |
+| `width`            | The new width of the renderer                                                                                                                                                            |
+| `height`           | The new height of the renderer                                                                                                                                                           |
+| `viewMatrix`       | The camera's matrix                                                                                                                                                                      |
+| `projectionMatrix` | The camera's projection matrix                                                                                                                                                           |
+| `framebuffer`      | The <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/createFramebuffer" target="_blank" rel="noopener noreferrer">`WebGLFramebuffer`</a> for the renderer |
+
+**Returns**: Nothing
 
 ## `reset()`
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -105,7 +105,13 @@ _Gets the proxied <a href="https://developer.mozilla.org/en-US/docs/Web/API/XRSe
 
 **Returns**: an `Object` representing the proxied/hijacked <a href="https://developer.mozilla.org/en-US/docs/Web/API/XRSession" target="_blank" rel="noopener noreferrer">XRSession</a> for this engine instance.
 
-## `grabdown`
+## `grabdown(handedness)`
+
+_Marks the given hand as in grabbing mode. Does nothing if there is no avatar/rig for this engine instance._
+
+**Parameters**: `handedness` is a string out of `left`, `right` that represents which hand is grabbing.
+
+**Returns**: Nothing
 
 ## `grabtriggerdown`
 


### PR DESCRIPTION
This PR documents all the remaining methods for the `XRPackage` and `XRPackageEngine` API:

`XRPackage`:

- add(p, options)
- grabrelease()
- loadAvatar()
- remove(p, options)
- setMatrix(m)
- setSchema(key, value)
- setPose(pose) **Note: is my description for the format of the `pose` parameter correct here?**

`XRPackageEngine`:

- equip(slot)
- getContext(type, opts)     
- getProxySession(options)   
- grabdown(handedness)       
- grabup(handedness)
- grabtriggerup(handedness) **Note: I'm a bit unsure if I've written the right description for this**
- grabtriggerdown(handedness) **Note: I'm a bit unsure if I've written the right description for this**
- grabuse(handedness)        
- render(pak, width, height, viewMatrix, projectionMatrix, framebuffer) **Note: are the parameters for this correct/could they be described better?**
- tick(timestamp, frame)

Part of #5.