### PR TITLE
Document the XRPackageManager (iframe `xrpackage` object) API

### DIFF
--- a/docs/dev-guides/7-xrpackage-api.md
+++ b/docs/dev-guides/7-xrpackage-api.md
@@ -5,7 +5,8 @@ title: XRPackage API
 
 The `XRPackage` API is documented here. See install instructions and development setup <a href="https://github.com/webaverse/xrpackage" target="_blank" rel="noopener noreferrer">at the GitHub repository</a>.
 
-The `XRPackageEngine` API is documented [in the next section](./8-xrpackage-engine-api.md).
+- The `XRPackageEngine` API is documented [in the next section](./8-xrpackage-engine-api.md).
+- The `XRPackageManager` API is documented [in a later section](./9-xrpackage-manager-api.md).
 
 **Note: This page is still in development, whilst the API is documented**.
 

--- a/docs/dev-guides/8-xrpackage-engine-api.md
+++ b/docs/dev-guides/8-xrpackage-engine-api.md
@@ -5,7 +5,8 @@ title: XRPackageEngine API
 
 The `XRPackageEngine` API is documented here. See install instructions and development setup <a href="https://github.com/webaverse/xrpackage" target="_blank" rel="noopener noreferrer">at the GitHub repository</a>.
 
-The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md).
+- The `XRPackage` API is documented [in the previous section](./7-xrpackage-api.md).
+- The `XRPackageManager` API is documented [in the next section](./9-xrpackage-manager-api.md).
 
 **Note: This page is still in development, whilst the API is documented**.
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -64,6 +64,10 @@ _Gets the value for the provided `key` for the `XRPackageEngine` for this `ifram
 
 **Returns**: Nothing
 
-## setSchema
+## setSchema(key, value)
+
+**Parameters**: the `key` and corresponding `value` to set for the schema for the `XRPackage` this iframe represents.
+
+**Returns**: Nothing
 
 ## setXrFramebuffer

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -70,4 +70,8 @@ _Gets the value for the provided `key` for the `XRPackageEngine` for this `ifram
 
 **Returns**: Nothing
 
-## setXrFramebuffer
+## setXrFramebuffer(xrfb)
+
+**Parameters**: `xrfb` is the <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/createFramebuffer" target="_blank" rel="noopener noreferrer">`WebGLFramebuffer`</a> to set for the XRSession being used in this `iframe`.
+
+**Returns**: Nothing

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -10,7 +10,11 @@ The `XRPackageManager` API is documented here. See install instructions and deve
 
 The `XRPackageManager` API is exposed to `iframe`s that are running `XRPackage`s, in the form of an `XRPackageManager` instance as the iframe's `window.xrpackage` variable.
 
-## constructor
+## constructor()
+
+**Parameters**: None
+
+**Returns**: an `XRPackageManager` instance.
 
 ## get engine
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -48,7 +48,22 @@ _Gets the value for the provided `key` for the `XRPackageEngine` for this `ifram
 
 **Returns**: the value that corresponds to the provided `key`.
 
-## iframeInit
+## iframeInit(options)
+
+**Parameters**: `options` is an `Object` with the following required keys:
+
+| Key         | Description                                                                                                                                                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `engine`    | The `XRPackageEngine` instance to be used for this `iframe`                                                                                                              |
+| `pkg`       | The `XRPackage` instance that this `iframe` is to render                                                                                                                 |
+| `indexHtml` | The HTML of the `start_url` of this package, as a UTF-8 string                                                                                                           |
+| `context`   | The <a href="https://developer.mozilla.org/en-US/docs/Web/API/RenderingContext" target="_blank" rel="noopener noreferrer">`RenderingContext`</a> to use for the renderer |
+| `id`        | A unique identifier for this `XRPackage`                                                                                                                                 |
+| `schema`    | The Schema for this `XRPackage`                                                                                                                                          |
+| `xrState`   | An `Object` representing the state for this `XRPackage`                                                                                                                  |
+| `XRPackage` | A reference to the `XRPackage` class to be used in this `iframe`                                                                                                         |
+
+**Returns**: Nothing
 
 ## remove(p)
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -26,6 +26,8 @@ The `XRPackageManager` API is exposed to `iframe`s that are running `XRPackage`s
 
 ## get children
 
+**Returns**: an `Array` of `XRPackage` instances that are children of the `XRPackage` that this `iframe` is representing.
+
 ## add
 
 ## getAvatar

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -56,7 +56,21 @@ _Gets the value for the provided `key` for the `XRPackageEngine` for this `ifram
 
 **Returns**: Nothing
 
-## render
+## render(width, height, viewMatrix, projectionMatrix, framebuffer)
+
+_Performs a render of the `XRPackageEngine` instance for this `iframe`._
+
+**Parameters**: all parameters are required, as follows:
+
+| Key                | Description                                                                                                                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `width`            | The new width of the renderer                                                                                                                                                            |
+| `height`           | The new height of the renderer                                                                                                                                                           |
+| `viewMatrix`       | The camera's matrix                                                                                                                                                                      |
+| `projectionMatrix` | The camera's projection matrix                                                                                                                                                           |
+| `framebuffer`      | The <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/createFramebuffer" target="_blank" rel="noopener noreferrer">`WebGLFramebuffer`</a> for the renderer |
+
+**Returns**: Nothing
 
 ## setMatrix(matrixArray)
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -18,6 +18,8 @@ The `XRPackageManager` API is exposed to `iframe`s that are running `XRPackage`s
 
 ## get engine
 
+**Returns**: the `XRPackageEngine` instance for this `iframe`.
+
 ## get package
 
 ## get children

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -7,3 +7,31 @@ The `XRPackageManager` API is documented here. See install instructions and deve
 
 - The `XRPackage` API is documented [in an earlier section](./7-xrpackage-api.md).
 - The `XRPackageEngine` API is documented [in the previous section](./8-xrpackage-engine-api.md).
+
+The `XRPackageManager` API is exposed to `iframe`s that are running `XRPackage`s, in the form of an `XRPackageManager` instance as the iframe's `window.xrpackage` variable.
+
+## constructor
+
+## get engine
+
+## get package
+
+## get children
+
+## add
+
+## getAvatar
+
+## getEnv
+
+## iframeInit
+
+## remove
+
+## render
+
+## setMatrix
+
+## setSchema
+
+## setXrFramebuffer

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -28,7 +28,11 @@ The `XRPackageManager` API is exposed to `iframe`s that are running `XRPackage`s
 
 **Returns**: an `Array` of `XRPackage` instances that are children of the `XRPackage` that this `iframe` is representing.
 
-## add
+## add(p)
+
+**Parameters**: `p` is an `XRPackage` instance to add to the `XRPackage` that this `iframe` represents.
+
+**Returns**: a `Promise` that resolves when the package is added successfully, or rejects if adding the package times out.
 
 ## getAvatar
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -40,7 +40,13 @@ The `XRPackageManager` API is exposed to `iframe`s that are running `XRPackage`s
 
 **Returns**: the rig for the avatar that this `XRPackage` is, if applicable.
 
-## getEnv
+## getEnv(key)
+
+_Gets the value for the provided `key` for the `XRPackageEngine` for this `iframe`._
+
+**Parameters**: `key` is the key for which the corresponding value should be returned.
+
+**Returns**: the value that corresponds to the provided `key`.
 
 ## iframeInit
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -34,7 +34,11 @@ The `XRPackageManager` API is exposed to `iframe`s that are running `XRPackage`s
 
 **Returns**: a `Promise` that resolves when the package is added successfully, or rejects if adding the package times out.
 
-## getAvatar
+## getAvatar()
+
+**Parameters**: None
+
+**Returns**: the rig for the avatar that this `XRPackage` is, if applicable.
 
 ## getEnv
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -58,7 +58,11 @@ _Gets the value for the provided `key` for the `XRPackageEngine` for this `ifram
 
 ## render
 
-## setMatrix
+## setMatrix(matrixArray)
+
+**Parameters**: `matrixArray` is the offset matrix between the camera and the avatar.
+
+**Returns**: Nothing
 
 ## setSchema
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -50,7 +50,11 @@ _Gets the value for the provided `key` for the `XRPackageEngine` for this `ifram
 
 ## iframeInit
 
-## remove
+## remove(p)
+
+**Parameters**: `p` is the `XRPackage` instance that is to be removed from the `XRPackage` that this iframe represents.
+
+**Returns**: Nothing
 
 ## render
 

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -1,0 +1,9 @@
+---
+id: xrpackage-manager-api
+title: XRPackageManager API
+---
+
+The `XRPackageManager` API is documented here. See install instructions and development setup <a href="https://github.com/webaverse/xrpackage" target="_blank" rel="noopener noreferrer">at the GitHub repository</a>.
+
+- The `XRPackage` API is documented [in an earlier section](./7-xrpackage-api.md).
+- The `XRPackageEngine` API is documented [in the previous section](./8-xrpackage-engine-api.md).

--- a/docs/dev-guides/9-xrpackage-manager-api.md
+++ b/docs/dev-guides/9-xrpackage-manager-api.md
@@ -22,6 +22,8 @@ The `XRPackageManager` API is exposed to `iframe`s that are running `XRPackage`s
 
 ## get package
 
+**Returns**: the `XRPackage` instance that this `iframe` is representing.
+
 ## get children
 
 ## add

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -12,6 +12,7 @@
       "dev-guides/examples",
       "dev-guides/xrpackage-api",
       "dev-guides/xrpackage-engine-api",
+      "dev-guides/xrpackage-manager-api",
       "dev-guides/xr-details-api",
       "dev-guides/examples",
       {


### PR DESCRIPTION
This PR documents the `XRPackageManager` API, which is accessible on the `iframe` `window.xrpackage` object:

- updates URLs, sidebar, so all the `XRPackage{,Manager,Engine}` APIs link to each other
- adds short intro to what the XRPackageManager API is and where it is found
- documents methods:
  - constructor
  - engine getter
  - package getter
  - children getter
  - add(p)
  - getAvatar()
  - getEnv(key)
  - remove(p)
  - setMatrix(matrixArray)    
  - setSchema(key, value)   
  - setXrFramebuffer(xrfb)  
  - render(width, height, viewMatrix, projectionMatrix, framebuffer)

Part of #5.